### PR TITLE
Keep extra files on remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ let options = {
     'src/**/*.spec.ts'
   ],
   excludeMode: 'remove',          // Behavior for excluded files ('remove' or 'ignore'), Default to 'remove'.
-  forceUpload: false              // Force uploading all files, Default to false(upload only newer files).
+  forceUpload: false,              // Force uploading all files, Default to false(upload only newer files).
+  removeExtraFiles: false          // Remove files on the target that are not present on the source or in the exclude list. Defaults to true.
 };
 
 deploy(config, options).then(() => {

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ let options = {
   excludeMode: 'remove',          // Behavior for excluded files ('remove' or 'ignore'), Default to 'remove'.
   forceUpload: false,             // Force uploading all files, Default to false(upload only newer files).
   concurrency: 100,               // Max number of SFTP tasks processed concurrently. Default to 100.
-  removeExtraFiles: false         // Remove files on the target that are not present on the source or in the exclude list. Defaults to true.
+  keepExtraFiles: false           // Keeps files on the target that are not present on the source or in the exclude list. Defaults to false.
 };
 
 deploy(config, options).then(() => {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -15,4 +15,5 @@ export interface SftpSyncOptions {
   exclude?: string[];
   excludeMode?: 'ignore'|'remove';
   forceUpload?: boolean;
+  removeExtraFiles?: boolean;
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -16,5 +16,5 @@ export interface SftpSyncOptions {
   excludeMode?: 'ignore'|'remove';
   forceUpload?: boolean;
   concurrency?: number;
-  removeExtraFiles?: boolean;
+  keepExtraFiles?: boolean;
 }

--- a/lib/sftpSync.ts
+++ b/lib/sftpSync.ts
@@ -57,7 +57,8 @@ export class SftpSync {
     this.options = Object.assign({
       dryRun: false,
       exclude: [],
-      excludeMode: 'remove'
+      excludeMode: 'remove',
+      removeExtraFiles: true
     }, options);
 
     this.client = new Client;

--- a/lib/sftpSync.ts
+++ b/lib/sftpSync.ts
@@ -58,7 +58,7 @@ export class SftpSync {
       exclude: [],
       excludeMode: 'remove',
       concurrency: 100,
-      removeExtraFiles: true,
+      keepExtraFiles: false,
       ...options,
     };
 

--- a/lib/syncTable.ts
+++ b/lib/syncTable.ts
@@ -43,7 +43,7 @@ export class SyncTableEntry {
       task.hasError = true;
     }
 
-    if (this.remoteStat !== null && !task.hasError && this.localStat !== this.remoteStat) {
+    if (this.remoteStat !== null && !task.hasError && this.localStat !== this.remoteStat && options.removeExtraFiles) {
       task.removeRemote = true;
     }
 

--- a/lib/syncTable.ts
+++ b/lib/syncTable.ts
@@ -43,7 +43,7 @@ export class SyncTableEntry {
       task.hasError = true;
     }
 
-    if (this.remoteStat !== null && !task.hasError && this.localStat !== this.remoteStat && options.removeExtraFiles) {
+    if (this.remoteStat !== null && !task.hasError && this.localStat !== this.remoteStat && !options.keepExtraFiles) {
       task.removeRemote = true;
     }
 


### PR DESCRIPTION
This pull request complements wangyucode/sftp-upload-action#2

It's not feasible to use the ``exclude`` on cases where we don't know which files exist in the source but does not exist on the remote.
The ideal behaviour for our use case would be to upload new files, without deleting any file from the remote.

I checked the repository where this is forked from and found #9 that seems to solve this.
This pull request just fixes its conflicts and moves it here since the original repository seems to be abandoned.

I would also appreciate if [wangyucode/sftp-upload-action](https://github.com/wangyucode/sftp-upload-action) would be updated to support these changes.